### PR TITLE
new: Support specifying translation(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 /src/pyinstaller_versionfile.egg-info/
 /venv/
+/.venv/
+/.vscode/
 /.tox/
 /.idea/
 /.coverage
 /testapp.spec
 /test/integrationtest/testapp.spec
+/**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The key/value pairs that be specified in the version file and [their official me
 | LegalCopyright | Copyright notices that apply to the file. This should include the full text of all notices, legal symbols, copyright dates, and so on. For example, "Copyright © 2000-2022, My Imaginary Company, Inc. All rights reserved.". |
 | OriginalFilename | Original name of the file, not including a path. This information enables an application to determine whether a file has been renamed by a user. For example, "SimpleApp.exe". |
 | ProductName | Name of the product with which the file is distributed, for example, "Simple App". |
+| Translation | Combinations of language and character sets supported by the application. See [the documentation](https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo-block#remarks) for the codes to use. Multiple values can be specified. |
 
 ## Usage
 pyinstaller-versionfile provides both a command line interface and a functional API.
@@ -41,8 +42,13 @@ InternalName: Simple App
 LegalCopyright: © My Imaginary Company. All rights reserved.
 OriginalFilename: SimpleApp.exe
 ProductName: Simple App
+Translation:
+  - langID: 0
+    charsetID: 1200
+  - langID: 1033
+    charsetID: 1252
 ```
-The encoding must be UTF-8.
+The encoding must be UTF-8. All fields are optional, you can choose to specify only those that are of interest to you.
 
 To create version-file from this, simple run:
 ```cmd

--- a/pylintrc
+++ b/pylintrc
@@ -4,6 +4,7 @@ load-plugins=pylint.extensions.mccabe
 [DESIGN]
 max-complexity=10
 min-similarity-lines=6
+max-attributes=10
 
 [FORMAT]
 max-line-length=120

--- a/src/pyinstaller_versionfile/version_file_template.txt
+++ b/src/pyinstaller_versionfile/version_file_template.txt
@@ -39,6 +39,6 @@ VSVersionInfo(
         StringStruct(u'ProductName', u'{{ProductName}}'),
         StringStruct(u'ProductVersion', u'{{Version}}')])
       ]), 
-    VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
+    VarFileInfo([VarStruct(u'Translation', [{{ Translation|join(", ") }}])])
   ]
 )

--- a/test/resources/metadata_with_translations.yml
+++ b/test/resources/metadata_with_translations.yml
@@ -1,0 +1,12 @@
+Version: 4.7.1.1
+CompanyName: My Imaginary Company
+FileDescription: Acceptance Test
+InternalName: Internal Acceptance Test
+LegalCopyright: © My Imaginary Company. All rights reserved.
+OriginalFilename: acceptancetest_metadata
+ProductName: Acceptance Test Unit Test
+Translation:
+  - langID: 0
+    charsetID: 1200
+  - langID: 1033
+    charsetID: 1252

--- a/test/unittest/test_metadata.py
+++ b/test/unittest/test_metadata.py
@@ -116,6 +116,7 @@ def test_load_file_does_not_exist_raises_input_error():
         ("legal_copyright", ""),
         ("original_filename", ""),
         ("product_name", ""),
+        ("translations", [1033, 1200]),
     ],
 )
 def test_from_file_missing_parameters_are_given_default_values(
@@ -226,3 +227,19 @@ def test_set_version_invalid_input_raises_validation_error():
     metadata = MetaData(version="0.8.1.5")
     with pytest.raises(exceptions.ValidationError):
         metadata.set_version("this is not a valid version string")
+
+
+def test_set_translations():
+    """
+    It is possible to set different translations / languages for the file.
+    See https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo-block#remarks
+    for possible values of langID and charsetID
+    """
+    testfile = TEST_DATA / "metadata_with_translations.yml"
+    metadata = MetaData.from_file(testfile)
+    assert metadata.translations == [
+        0,     # langID: language independent
+        1200,  # charsetID: Unicode
+        1033,  # langID: U.S. English
+        1252,  # charsetID: Multilingual
+    ]


### PR DESCRIPTION
Support specification of one or multiple translations via language ID and charset ID. 

Example:
```yaml
Version: 4.7.1.1
CompanyName: My Imaginary Company
FileDescription: Acceptance Test
InternalName: Internal Acceptance Test
LegalCopyright: © My Imaginary Company. All rights reserved.
OriginalFilename: acceptancetest_metadata
ProductName: Acceptance Test Unit Test
Translation:
  - langID: 0
    charsetID: 1200
  - langID: 1033
    charsetID: 1252
```

For more information, see:
https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo-block#remarks

`langID: 0` means "language independent".

Closes #13 