### PR TITLE
breaking: drop support for Python < 3.9; test with Python up to 3.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9, 3.10, 3.11, 3.12]
+        python: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,11 +13,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install dependencies
         run: pip install tox tox-gh-actions
       - name: Run linter
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.9, 3.10, 3.11, 3.12]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -47,14 +47,14 @@ jobs:
     needs: unittest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install dependencies
         run: pip install tox
       - name: Run integration tests
-        run: tox -e py39-tests-win
+        run: tox -e py312-tests-win
         env:
           includeE2E: True

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 # include all requirements necessary to run the application
 -r requirements.txt
 
+setuptools
 pylint
 pytest
 tox

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,5 @@ setuptools.setup(
         "Topic :: Software Development :: Build Tools",
         "Environment :: Console",
     ],
-    python_requires='>=3.6'
+    python_requires='>=3.9'
 )

--- a/src/pyinstaller_versionfile/metadata.py
+++ b/src/pyinstaller_versionfile/metadata.py
@@ -63,7 +63,7 @@ class MetaData(object):
         if not isinstance(data, dict):
             raise exceptions.InputError(f"Input file must contain a mapping, but is: {type(data)}")
         version = data.get("Version", "0.0.0.0")
-        path = (Path(filepath).parent/version)
+        path = Path(filepath).parent/version
         if path.is_file():
             version = path.read_text().strip()
         translations = cls._get_translations(data)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39}-tests,lint
+envlist = {py39,py310,py311,py312}-tests,lint
 skip_missing_interpreters = true
 
 [testenv]
@@ -40,7 +40,7 @@ deps =
     pystache
     gitchangelog
 
-whitelist_externals:
+allowlist_externals:
     cmd
 
 commands =
@@ -48,10 +48,10 @@ commands =
 
 [gh-actions]
 python = 
-    3.6: py36-tests
-    3.7: py37-tests
-    3.8: py38-tests
     3.9: py39-tests
+    3.10: py3.10-tests
+    3.11: py3.11-tests
+    3.12: py3.12-tests
 
 # Pytest configuration
 [pytest]


### PR DESCRIPTION
* Drop support for Python versions that are EOL (or very soon, in case of Python 3.8)
* Update versions of GitHub actions
* Add current Python versions to GitHub actions and test against them
* Fix linter warning that arose due to a newly implemented check